### PR TITLE
Remove extra AVR headers

### DIFF
--- a/PlayingWithFusion_MAX31856.cpp
+++ b/PlayingWithFusion_MAX31856.cpp
@@ -58,16 +58,6 @@ PWF_MAX31856::PWF_MAX31856(uint8_t CSx)
   digitalWrite(_cs, HIGH);
 }
 
-PWF_MAX31856::PWF_MAX31856(uint8_t CSx, uint8_t FAULTx, uint8_t DRDYx)
-    : PWF_MAX31856(CSx)
-{
-   _fault = FAULTx;
-   _drdy = DRDYx;  
-   
-   pinMode(_fault, INPUT);
-   pinMode(_drdy, INPUT);	
-}
-
 uint8_t PWF_MAX31856::_sing_reg_read(uint8_t RegAdd)
 {
 	digitalWrite(_cs, LOW);						// set pin low to start talking to IC

--- a/PlayingWithFusion_MAX31856.cpp
+++ b/PlayingWithFusion_MAX31856.cpp
@@ -46,16 +46,12 @@
 ***************************************************************************/
 #include "PlayingWithFusion_MAX31856.h"
 
-PWF_MAX31856::PWF_MAX31856(uint8_t CSx, uint8_t FAULTx, uint8_t DRDYx)
+PWF_MAX31856::PWF_MAX31856(uint8_t CSx)
 {
   // Function to initialize thermocouple channel, load private variables
   _cs = CSx;
-  _fault = FAULTx;
-  _drdy = DRDYx;
   
   pinMode(_cs, OUTPUT);
-  pinMode(_fault, INPUT);
-  pinMode(_drdy, INPUT);
   
   // immediately pull CS pin high to avoid conflicts on SPI bus
   digitalWrite(_cs, HIGH);

--- a/PlayingWithFusion_MAX31856.cpp
+++ b/PlayingWithFusion_MAX31856.cpp
@@ -57,6 +57,16 @@ PWF_MAX31856::PWF_MAX31856(uint8_t CSx)
   digitalWrite(_cs, HIGH);
 }
 
+PWF_MAX31856::PWF_MAX31856(uint8_t CSx, uint8_t FAULTx, uint8_t DRDYx)
+    : PWF_MAX31856(CSx)
+{
+   _fault = FAULTx;
+   _drdy = DRDYx;  
+   
+   pinMode(_fault, INPUT);
+   pinMode(_drdy, INPUT);	
+}
+
 uint8_t PWF_MAX31856::_sing_reg_read(uint8_t RegAdd)
 {
 	digitalWrite(_cs, LOW);						// set pin low to start talking to IC

--- a/PlayingWithFusion_MAX31856.h
+++ b/PlayingWithFusion_MAX31856.h
@@ -41,8 +41,8 @@
 #define PWF_MAX31856_h
 
 #include "Arduino.h"			// use "WProgram.h" for IDE <1.0
-#include "avr/pgmspace.h"
-#include "util/delay.h"
+//#include "avr/pgmspace.h"
+//#include "util/delay.h"
 #include "stdlib.h"
 #include "PlayingWithFusion_MAX31856_STRUCT.h"
 #include "SPI.h"

--- a/PlayingWithFusion_MAX31856.h
+++ b/PlayingWithFusion_MAX31856.h
@@ -109,7 +109,7 @@
 class PWF_MAX31856
 {
  public:
-  PWF_MAX31856(uint8_t CSx, uint8_t FAULTx, uint8_t DRDYx);
+  PWF_MAX31856(uint8_t CSx);
   void MAX31856_config(uint8_t TC_TYPE, uint8_t FILT_FREQ, uint8_t AVG_MODE, uint8_t MEAS_MODE);
   void MAX31856_CJ_offset(int8_t offset_val);	// offset is 2^-4 degC/bit
   void SPIbus_Init(void);
@@ -117,7 +117,7 @@ class PWF_MAX31856
   void MAX31856_1shot_start(void);
 
  private:
-  uint8_t _cs, _fault, _drdy;
+  uint8_t _cs;
   uint8_t _sing_reg_read(uint8_t RegAdd);
   void _sing_reg_write(uint8_t RegAdd, uint8_t BitMask, uint8_t RegData);
 };

--- a/PlayingWithFusion_MAX31856.h
+++ b/PlayingWithFusion_MAX31856.h
@@ -41,8 +41,6 @@
 #define PWF_MAX31856_h
 
 #include "Arduino.h"			// use "WProgram.h" for IDE <1.0
-//#include "avr/pgmspace.h"
-//#include "util/delay.h"
 #include "stdlib.h"
 #include "PlayingWithFusion_MAX31856_STRUCT.h"
 #include "SPI.h"
@@ -110,6 +108,7 @@ class PWF_MAX31856
 {
  public:
   PWF_MAX31856(uint8_t CSx);
+  PWF_MAX31856(uint8_t CSx, uint8_t FAULTx, uint8_t DRDYx);
   void MAX31856_config(uint8_t TC_TYPE, uint8_t FILT_FREQ, uint8_t AVG_MODE, uint8_t MEAS_MODE);
   void MAX31856_CJ_offset(int8_t offset_val);	// offset is 2^-4 degC/bit
   void SPIbus_Init(void);
@@ -117,7 +116,7 @@ class PWF_MAX31856
   void MAX31856_1shot_start(void);
 
  private:
-  uint8_t _cs;
+  uint8_t _cs, _fault, _drdy;
   uint8_t _sing_reg_read(uint8_t RegAdd);
   void _sing_reg_write(uint8_t RegAdd, uint8_t BitMask, uint8_t RegData);
 };

--- a/PlayingWithFusion_MAX31856.h
+++ b/PlayingWithFusion_MAX31856.h
@@ -84,10 +84,10 @@
 
 // CR1 Configs
 #define AVG_SEL_1SAMP	0x00
-#define AVG_SEL_2SAMP	0x20
-#define AVG_SEL_4SAMP	0x40
-#define AVG_SEL_8SAMP	0x60
-#define AVG_SEL_16SAMP	0x80
+#define AVG_SEL_2SAMP	0x10
+#define AVG_SEL_4SAMP	0x20
+#define AVG_SEL_8SAMP	0x30
+#define AVG_SEL_16SAMP	0x40
 #define B_TYPE			0x00
 #define E_TYPE			0x01
 #define J_TYPE			0x02

--- a/PlayingWithFusion_MAX31856_STRUCT.h
+++ b/PlayingWithFusion_MAX31856_STRUCT.h
@@ -40,9 +40,6 @@
 #ifndef PWF_MAX31856_STRUCT_H
 #define PWF_MAX31856_STRUCT_H
 
-//#include "avr/pgmspace.h"
-
-
 struct var_max31856{
     long int  lin_tc_temp;	// linearized TC temperature, 0.0078125 decC/bit (2^-7)
     int16_t  ref_jcn_temp;	// temp of chip ref jcn, 0.015625 deg C/bit (2^-6)

--- a/PlayingWithFusion_MAX31856_STRUCT.h
+++ b/PlayingWithFusion_MAX31856_STRUCT.h
@@ -40,7 +40,7 @@
 #ifndef PWF_MAX31856_STRUCT_H
 #define PWF_MAX31856_STRUCT_H
 
-#include "avr/pgmspace.h"
+//#include "avr/pgmspace.h"
 
 
 struct var_max31856{


### PR DESCRIPTION
Removed unused(?) AVR header files, making code compatible for esp8266 arduino core.