### PR TITLE
Explicity Write CJTO Register

### DIFF
--- a/src/PWFusion_MAX31856.cpp
+++ b/src/PWFusion_MAX31856.cpp
@@ -169,11 +169,14 @@ void MAX31856::config(Tc_Type TC_TYPE, uint8_t FILT_FREQ, uint8_t AVG_MODE, Max3
 /*   LTHFTH, 05h/85h: Linearize temperature high fault thresh MSB (bit 7 is sign)
    LTHFTL, 06h/86h: Linearize temperature high fault thresh LSB
    LTLFTH, 07h/87h: Linearize temperature low fault thresh MSB (bit 7 is sign)
-   LTLFTL, 08h/88h: Linearize temperature low fault thresh LSB */
+   LTLFTL, 08h/88h: Linearize temperature low fault thresh LSB 
+   CJTO, 09h/89h: Cold Junction Temperature Offset*/
    writeByte(REG_LTHFTH, 0x7F);
    writeByte(REG_LTHFTL, 0xFF);
    writeByte(REG_LTLFTH, 0xFF);
    writeByte(REG_LTLFTL, 0x80);
+   // Explicitly set cold-junction offset to zero
+   writeByte(REG_CJTO, 0x00);
 }
 
 

--- a/src/PWFusion_MAX31856.h
+++ b/src/PWFusion_MAX31856.h
@@ -71,17 +71,6 @@ typedef enum {
   CONV_SINGL,         // Single shot conversion mode (slower)
 } Max31856_Conversion_Mode;
 
-typedef enum {
-  TYPE_B,
-  TYPE_E,
-  TYPE_J,
-  TYPE_K,
-  TYPE_N,
-  TYPE_R,
-  TYPE_S,
-  TYPE_T,
-} Tc_Type;
-
 
 // CR0 Configs
 #define CMODE_OFF       0x00
@@ -134,6 +123,17 @@ typedef enum {
 #define TC_FAULT_VOLTAGE_OOR  0x02
 #define TC_FAULT_OPEN         0x01
 
+
+typedef enum {
+  TYPE_B = B_TYPE,
+  TYPE_E = E_TYPE,
+  TYPE_J = J_TYPE,
+  TYPE_K = K_TYPE,
+  TYPE_N = N_TYPE,
+  TYPE_R = R_TYPE,
+  TYPE_S = S_TYPE,
+  TYPE_T = T_TYPE,
+} Tc_Type;
 
 class MAX31856
 {


### PR DESCRIPTION
# Overview

Before this PR, the MAX31856 library was not explicitly setting the MAX31856 IC's Cold-Junction Temperature Offset register, which the IC adds to the measured temperature, and is meant to be used for compensation. 

However, it's suspected that not explicitly setting this register with a value caused the IC to report erroneous internal temperatures because the cold junction temperature offset register was populated with a value other than the datasheets specified value of `0x00`

This PR fixes this by *explicitly* initializing this register to `0x00`

# What's In This PR

The configure function has been altered to reflect the above behavior

**Nit-Picky thing I Fixed**

Also in this PR, I changed the `TC_Type` enum to map its values to the macros that are defined before it. Both the enum and the macros had the same values, but it bugged me that the enum values were not linked to the macros at all. Better to have a single source of truth. 