### PR TITLE
Proactively fix <0 Temp Bug

### DIFF
--- a/src/PWFusion_MAX31856.cpp
+++ b/src/PWFusion_MAX31856.cpp
@@ -189,7 +189,6 @@ void MAX31856::sample()
 {
    uint16_t rawCJReg;
    uint32_t rawTCReg;
-   int16_t m;
    // Start by reading SR for any faults, exit if faults present, though some
    // faults could potentially be dealt with
    status = readByte(REG_SR);


### PR DESCRIPTION
# Overview

When looking into the MAX31856 library code for #6 , I noticed that we were not properly accounting for the conversion between *sign-magnitude* and *twos-compliment* signed integer formats when reading from MAX31856 registers. 

Because the math works out, any internal temperatures greater than zero would not have exhibited any strange behaviors, but using this board in an environment where the temperature would be less than zero would result in erroneous values. 

# What's In This PR

This PR implements a fix for the above by adding two functions for converting from signed-magnitude and twos compliment, as well as implementing them in the sample function. 